### PR TITLE
Symfony 6 compatibility in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "require": {
         "php": "^7.1 || ^8.0",
         "pugx/shortid-doctrine": "^0.7",
-        "symfony/config": "^3.4 || ^4.4 || ^5.0",
-        "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0",
-        "symfony/http-kernel": "^3.4 || ^4.4 || ^5.0"
+        "symfony/config": "^3.4 || ^4.4 || ^5.0 || ^6.0",
+        "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0 || ^6.0",
+        "symfony/http-kernel": "^3.4 || ^4.4 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "pugx/shortid-doctrine": "^0.7",
+        "pugx/shortid-doctrine": "^1.0",
         "symfony/config": "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^3.4 || ^4.4 || ^5.0 || ^6.0"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1 || ^8.0",
-        "pugx/shortid-doctrine": "^1.0",
+        "pugx/shortid-doctrine": "^0.7",
         "symfony/config": "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^3.4 || ^4.4 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^3.4 || ^4.4 || ^5.0 || ^6.0"


### PR DESCRIPTION
Just adds the 6.x versions of Symfony packages to composer.json. Seems as that works well.

BTW it could be a good idea to switch to pugx/shortid-doctrine 1.0 that was released some weeks ago. But I didn't try that, yet.